### PR TITLE
Add converted_to_discussion issue event type

### DIFF
--- a/library/src/main/java/com/meisolsson/githubsdk/model/IssueEventType.java
+++ b/library/src/main/java/com/meisolsson/githubsdk/model/IssueEventType.java
@@ -37,6 +37,7 @@ public enum IssueEventType {
     @Json(name = "connected") Connected,
     @Json(name = "convert_to_draft") ConvertToDraft,
     @Json(name = "converted_note_to_issue") ConvertedNoteToIssue,
+    @Json(name = "converted_to_discussion") ConvertedToDiscussion,
     /*TODO Is this working correctly? This is used by the issue timeline api which is not
         yet stable. When it' stable this needs to be tested*/
     @Json(name = "cross-referenced") CrossReferenced,


### PR DESCRIPTION
Apparently issues that are converted to a discussion don't get deleted anymore.